### PR TITLE
ConfiguredJob support

### DIFF
--- a/activejob_delayed_execution.gemspec
+++ b/activejob_delayed_execution.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activejob', '>= 4.2.0'
-  spec.add_development_dependency 'bundler', '~> 1.11'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec', '>= 3.8.0'
 end

--- a/lib/active_job_delayed_execution/delayable.rb
+++ b/lib/active_job_delayed_execution/delayable.rb
@@ -1,7 +1,7 @@
 module ActiveJobDelayedExecution
   module Delayable
-    def delayed
-      ActiveJobDelayedExecution::Proxy.new(self)
+    def delayed(options = {})
+      ActiveJobDelayedExecution::Proxy.new(self, options)
     end
   end
 end

--- a/lib/active_job_delayed_execution/proxy.rb
+++ b/lib/active_job_delayed_execution/proxy.rb
@@ -1,11 +1,12 @@
 module ActiveJobDelayedExecution
   class Proxy < BasicObject
-    def initialize(object)
+    def initialize(object, options = {})
       @object = object
+      @options = options
     end
 
     def method_missing(name, *args)
-      DelayedExecutionJob.perform_later(@object, name.to_s, *args)
+      DelayedExecutionJob.set(@options).perform_later(@object, name.to_s, *args)
     end
   end
 end

--- a/lib/active_job_delayed_execution/version.rb
+++ b/lib/active_job_delayed_execution/version.rb
@@ -1,3 +1,3 @@
 module ActiveJobDelayedExecution
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end

--- a/spec/active_job_delayed_execution/delayable_spec.rb
+++ b/spec/active_job_delayed_execution/delayable_spec.rb
@@ -1,7 +1,5 @@
 describe ActiveJobDelayedExecution::Delayable do
   describe '#delayed' do
-    subject { string.delayed }
-
     let(:string) do
       'hello'.tap do |string|
         string.extend(described_class)
@@ -17,6 +15,24 @@ describe ActiveJobDelayedExecution::Delayable do
       end
     end
 
-    it { expect(get_class(subject)).to be(ActiveJobDelayedExecution::Proxy) }
+    context 'without arguments' do
+      it { expect(get_class(string.delayed)).to be(ActiveJobDelayedExecution::Proxy) }
+
+      it 'enqueues DelayedExecutionJob without options' do
+        string.delayed.do_something
+
+        expect(enqueued_jobs.map { |v| v[:job] }).to eq([ActiveJobDelayedExecution::DelayedExecutionJob])
+        expect(enqueued_jobs.map { |v| v[:queue] }).to eq(['default'])
+      end
+    end
+
+    context 'with arguments' do
+      it 'enqueues DelayedExecutionJob with options' do
+        string.delayed(queue: 'low').do_something
+
+        expect(enqueued_jobs.map { |v| v[:job] }).to eq([ActiveJobDelayedExecution::DelayedExecutionJob])
+        expect(enqueued_jobs.map { |v| v[:queue] }).to eq(['low'])
+      end
+    end
   end
 end


### PR DESCRIPTION
delayed method supports ConfiguredJob.

```ruby
# ActiveJobDealyedExecution::DelayedJob.set(queue: 'high').perform_later(model, 'do_something')
model.delayed(queue: 'high').do_something 
```